### PR TITLE
OnePlus-style redesign with home screens

### DIFF
--- a/add-item.html
+++ b/add-item.html
@@ -32,37 +32,38 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Add New Product</h1>
     <form action="item-list.html" method="get" class="space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Title</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Brand</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">MRP</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Price</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Unit</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Quantity in Stock</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Category</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Description</label>
@@ -70,18 +71,20 @@ tailwind.config = {
       </div>
       <div>
         <label class="text-sm text-text-secondary">Image URL</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Add Product</button>
     </form>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/basic-onboarding.html
+++ b/basic-onboarding.html
@@ -32,21 +32,22 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Basic Onboarding</h1>
     <form action="consumer-onboarding.html" method="get" class="space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Full Name</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="John Doe" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">City</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Society</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Role</label>
@@ -58,13 +59,17 @@ tailwind.config = {
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Continue</button>
     </form>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/bulk-upload.html
+++ b/bulk-upload.html
@@ -31,7 +31,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <header class="max-w-lg mx-auto mb-6 text-center">
     <h1 class="text-lg font-bold text-text-primary mb-4">Bulk Upload</h1>
   </header>
@@ -39,18 +40,20 @@ tailwind.config = {
     <form action="item-list.html" method="get" class="bg-white p-4 rounded shadow space-y-4" enctype="multipart/form-data">
       <div>
         <label class="text-sm text-text-secondary">Upload CSV/XLS</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Upload</button>
     </form>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/cart.html
+++ b/cart.html
@@ -31,7 +31,8 @@ tailwind.config = {
 </script>
 <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
 <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
   <header class="w-full max-w-xl text-center mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">Your Cart</h1>
@@ -69,11 +70,15 @@ tailwind.config = {
   </section>
   
 </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
+
+</div>
 </body>
 </html>

--- a/checkout.html
+++ b/checkout.html
@@ -56,7 +56,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
 <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
   <header class="w-full max-w-xl text-center mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">Checkout</h1>
@@ -89,11 +90,11 @@ tailwind.config = {
       <div>
         <p class="text-sm text-text-secondary">Payment Mode</p>
         <label class="text-sm text-text-secondary">
-          <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+          <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
           <span>Wallet</span>
         </label>
         <label class="text-sm text-text-secondary">
-          <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+          <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
           <span>Cash on Delivery</span>
         </label>
       </div>
@@ -102,11 +103,15 @@ tailwind.config = {
   </section>
   
 </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
+
+</div>
 </body>
 </html>

--- a/consumer-onboarding.html
+++ b/consumer-onboarding.html
@@ -32,17 +32,18 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Complete your consumer profile</h1>
     <form action="shops.html" method="get" class="space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Flat Number</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Profile Image URL</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Gender</label>
@@ -54,22 +55,26 @@ tailwind.config = {
       </div>
       <div>
         <label class="text-sm text-text-secondary">Date of Birth</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Preferred Language</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Continue</button>
     </form>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/create-shop.html
+++ b/create-shop.html
@@ -32,13 +32,14 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Create Your Shop</h1>
     <form action="vendor-dashboard.html" method="get" class="space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Shop Name</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="John Doe" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Shop Type</label>
@@ -51,22 +52,26 @@ tailwind.config = {
       </div>
       <div>
         <label class="text-sm text-text-secondary">Logo URL (optional)</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div class="flex items-center">
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
         <label class="text-sm text-text-secondary">Is Open</label>
       </div>
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Create Shop</button>
     </form>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/customer-home.html
+++ b/customer-home.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Customer Home</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+  tailwind.config = {
+    theme:{extend:{
+      colors:{primary:'#FF9933','primary-dark':'#e68a00',accent:'#138808','accent-dark':'#0f6a06',background:'#FFFFFF','background-soft':'#F5F5F5','text-primary':'#212121','text-secondary':'#6B7280',divider:'#E0E0E0',error:'#DC3545',success:'#138808',warning:'#FFC107',info:'#17A2B8'},
+      boxShadow:{card:'0 1px 3px rgba(0,0,0,.1)',elevated:'0 4px 12px rgba(0,0,0,.15)'}
+    }}
+  }
+  </script>
+</head>
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
+    <main class="p-4 flex-grow">
+      <h1 class="text-lg font-bold text-text-primary mb-4">Welcome</h1>
+      <div class="grid grid-cols-2 gap-4">
+        <a href="shops.html" class="bg-background-soft rounded-lg shadow-card p-4 flex flex-col items-center">
+          <img src="https://unpkg.com/heroicons@2.1.0/24/building-storefront.svg" class="w-10 mb-2" />
+          <span>Shops</span>
+        </a>
+        <a href="cart.html" class="bg-background-soft rounded-lg shadow-card p-4 flex flex-col items-center">
+          <img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="w-10 mb-2" />
+          <span>Cart</span>
+        </a>
+        <a href="order-history.html" class="bg-background-soft rounded-lg shadow-card p-4 flex flex-col items-center">
+          <img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="w-10 mb-2" />
+          <span>Orders</span>
+        </a>
+        <a href="wallet.html" class="bg-background-soft rounded-lg shadow-card p-4 flex flex-col items-center">
+          <img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="w-10 mb-2" />
+          <span>Wallet</span>
+        </a>
+      </div>
+    </main>
+    <nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+      <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+      <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+      <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+      <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+      <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+    </nav>
+  </div>
+</body>
+</html>

--- a/dashboard.html
+++ b/dashboard.html
@@ -32,17 +32,22 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Dashboard</h1>
     <p class="text-sm text-text-secondary">Welcome to your dashboard.</p>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
 
+
+</div>
 </body>
 </html>

--- a/edit-vendor-profile.html
+++ b/edit-vendor-profile.html
@@ -31,7 +31,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <header class="max-w-lg mx-auto mb-6 text-center">
     <h1 class="text-lg font-bold text-text-primary mb-4">Edit Vendor Profile</h1>
   </header>
@@ -39,15 +40,15 @@ tailwind.config = {
     <form action="vendor-profile.html" method="get" class="bg-white p-4 rounded shadow space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Business Name</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="John Doe" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Business Type</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">GST No.</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Address</label>
@@ -55,22 +56,26 @@ tailwind.config = {
       </div>
       <div>
         <label class="text-sm text-text-secondary">Shop Name</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="221B Baker Street" value="John Doe" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Shop Type</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Save Changes</button>
     </form>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -32,18 +32,23 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Welcome to Habrio</h1>
     <a href="login.html" class="inline-block px-6 py-3 bg-blue-600 text-white rounded hover:bg-blue-700">Login / Get Started</a>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/issue-center.html
+++ b/issue-center.html
@@ -32,7 +32,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <header class="max-w-2xl mx-auto mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">Issue Center</h1>
   </header>
@@ -81,13 +82,15 @@ tailwind.config = {
       </div>
     </section>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/item-list.html
+++ b/item-list.html
@@ -31,7 +31,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <header class="max-w-lg mx-auto mb-6 text-center">
     <h1 class="text-lg font-bold text-text-primary mb-4">My Items</h1>
   </header>
@@ -67,13 +68,15 @@ tailwind.config = {
       </tbody>
     </table>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -32,24 +32,29 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Login</h1>
     <form action="verify-otp.html" method="get" class="space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Phone Number</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="9999999999" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Send OTP</button>
     </form>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/mark-delivered.html
+++ b/mark-delivered.html
@@ -32,7 +32,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <header class="max-w-2xl mx-auto mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">Mark Order Delivered</h1>
   </header>
@@ -54,13 +55,15 @@ tailwind.config = {
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Mark as Delivered</button>
     </form>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/modify-order.html
+++ b/modify-order.html
@@ -32,7 +32,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <header class="max-w-2xl mx-auto mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">Modify Order #HBR1093</h1>
   </header>
@@ -51,33 +52,35 @@ tailwind.config = {
           <tr class="border-b">
             <td class="py-2">Rice</td>
             <td class="text-center">2</td>
-            <td class="text-center"><input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
-            <td class="text-center"><input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
+            <td class="text-center"><input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
+            <td class="text-center"><input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
           </tr>
           <tr class="border-b">
             <td class="py-2">Dal</td>
             <td class="text-center">1</td>
-            <td class="text-center"><input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
-            <td class="text-center"><input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
+            <td class="text-center"><input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
+            <td class="text-center"><input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
           </tr>
           <tr>
             <td class="py-2">Soap</td>
             <td class="text-center">3</td>
-            <td class="text-center"><input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
-            <td class="text-center"><input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
+            <td class="text-center"><input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
+            <td class="text-center"><input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary"></td>
           </tr>
         </tbody>
       </table>
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Submit Changes</button>
     </form>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/order-confirmed.html
+++ b/order-confirmed.html
@@ -32,20 +32,25 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Your order has been placed! 🎉</h1>
     <p class="text-sm text-text-secondary">Order ID: <span class="font-mono">#HBR1234</span></p>
     <p class="text-sm text-text-secondary">Estimated delivery: 20–30 min</p>
     <a href="order-history.html" class="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Go to Orders</a>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/order-history.html
+++ b/order-history.html
@@ -56,7 +56,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
 <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
   <header class="w-full max-w-xl text-center mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">My Orders</h1>
@@ -119,11 +120,15 @@ tailwind.config = {
   </section>
   
 </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
+
+</div>
 </body>
 </html>

--- a/order-issue.html
+++ b/order-issue.html
@@ -31,13 +31,14 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Report an Issue</h1>
     <form action="order-history.html" method="get" class="space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Order ID</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Describe Issue</label>
@@ -46,13 +47,17 @@ tailwind.config = {
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Submit</button>
     </form>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/order-list.html
+++ b/order-list.html
@@ -32,7 +32,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <header class="max-w-2xl mx-auto mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">Incoming Orders</h1>
   </header>
@@ -61,13 +62,15 @@ tailwind.config = {
       </div>
     </div>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/order-summary.html
+++ b/order-summary.html
@@ -55,7 +55,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
 <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
   <header class="w-full max-w-xl text-center mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">Order Summary</h1>
@@ -90,11 +91,15 @@ tailwind.config = {
   </section>
   
 </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
+
+</div>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -31,20 +31,25 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <img src="https://via.placeholder.com/100" alt="Profile" class="mx-auto rounded-full">
     <h1 class="text-lg font-bold text-text-primary mb-4">John Doe</h1>
     <p class="text-sm text-text-secondary">Flat A-101, Green Society</p>
     <p class="text-sm text-text-secondary">Cityville</p>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/rate-order.html
+++ b/rate-order.html
@@ -32,29 +32,30 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Rate Your Order</h1>
     <form action="order-history.html" method="get" class="space-y-4">
       <div class="flex justify-center space-x-2">
         <label class="text-sm text-text-secondary">
-          <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+          <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
           <span class="text-2xl text-yellow-500">&#9733;</span>
         </label>
         <label class="text-sm text-text-secondary">
-          <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+          <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
           <span class="text-2xl text-yellow-500">&#9733;</span>
         </label>
         <label class="text-sm text-text-secondary">
-          <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+          <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
           <span class="text-2xl text-yellow-500">&#9733;</span>
         </label>
         <label class="text-sm text-text-secondary">
-          <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+          <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
           <span class="text-2xl text-yellow-500">&#9733;</span>
         </label>
         <label class="text-sm text-text-secondary">
-          <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+          <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
           <span class="text-2xl text-yellow-500">&#9733;</span>
         </label>
       </div>
@@ -65,13 +66,17 @@ tailwind.config = {
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Submit Rating</button>
     </form>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/return-request.html
+++ b/return-request.html
@@ -31,13 +31,14 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Return Request</h1>
     <form action="order-history.html" method="get" class="space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Order ID</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Reason</label>
@@ -46,13 +47,17 @@ tailwind.config = {
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Submit</button>
     </form>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/shop-items.html
+++ b/shop-items.html
@@ -56,7 +56,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
 <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
   <header class="w-full max-w-xl flex justify-between items-center mb-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Grocery Mart</h1>
@@ -134,11 +135,15 @@ tailwind.config = {
   </section>
   
 </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
+
+</div>
 </body>
 </html>

--- a/shops.html
+++ b/shops.html
@@ -56,7 +56,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
 <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
   <header class="w-full max-w-xl text-center mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">Nearby Shops in Your Society</h1>
@@ -109,11 +110,15 @@ tailwind.config = {
   </section>
   
 </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
+
+</div>
 </body>
 </html>

--- a/update_html.py
+++ b/update_html.py
@@ -1,0 +1,40 @@
+import re, glob, os
+customer_nav = """
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+</nav>"""
+
+vendor_nav = """
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>"""
+
+vendor_files = {
+"add-item.html","bulk-upload.html","create-shop.html","edit-vendor-profile.html","issue-center.html","item-list.html","mark-delivered.html","modify-order.html","order-list.html","vendor-basic-onboarding.html","vendor-dashboard.html","vendor-index.html","vendor-kyc.html","vendor-login.html","vendor-profile.html","vendor-wallet.html","withdraw.html"}
+
+for path in glob.glob("*.html"):
+    nav = vendor_nav if path in vendor_files else customer_nav
+    with open(path) as f:
+        html = f.read()
+    html = re.sub(r'<body class="[^"]*bg-background-soft[^"]*">', '<body class="min-h-screen bg-background-soft flex flex-col items-center">\n  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">', html)
+    html = re.sub(r'<nav class="[^"]*fixed bottom-0[\s\S]*?</nav>', '', html)
+    html = re.sub(r'<footer class="[^"]*fixed bottom-0[\s\S]*?</footer>', '', html)
+    html = html.replace('</main>', '</main>\n'+nav)
+    html = html.replace('</body>', '</div>\n</body>')
+    html = re.sub(r'(Phone Number.*?\n\s*)<input', r'\1<input value="9999999999"', html, flags=re.S)
+    html = re.sub(r'(OTP.*?\n\s*)<input', r'\1<input value="123456"', html, flags=re.S)
+    html = re.sub(r'(Name.*?\n\s*)<input', r'\1<input value="John Doe"', html, flags=re.S)
+    html = re.sub(r'(Address.*?\n\s*)<input', r'\1<input value="221B Baker Street"', html, flags=re.S)
+    html = re.sub(r'(Amount.*?\n\s*)<input', r'\1<input value="500"', html, flags=re.S)
+    html = re.sub(r'(Bank Account.*?\n\s*)<input', r'\1<input value="XXXXXX1234"', html, flags=re.S)
+    html = re.sub(r'<input(?![^>]*value=)', '<input value="Sample"', html)
+    with open(path, 'w') as f:
+        f.write(html)

--- a/vendor-basic-onboarding.html
+++ b/vendor-basic-onboarding.html
@@ -32,36 +32,39 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Vendor Onboarding</h1>
     <form action="vendor-kyc.html" method="get" class="space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Name</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="John Doe" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">City</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Society</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Role</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Continue</button>
     </form>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/vendor-dashboard.html
+++ b/vendor-dashboard.html
@@ -32,7 +32,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <header class="max-w-2xl mx-auto mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">Vendor Dashboard</h1>
   </header>
@@ -61,13 +62,15 @@ tailwind.config = {
       </div>
     </div>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/vendor-home.html
+++ b/vendor-home.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vendor Dashboard</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+  tailwind.config = {
+    theme:{extend:{
+      colors:{primary:'#FF9933','primary-dark':'#e68a00',accent:'#138808','accent-dark':'0f6a06',background:'#FFFFFF','background-soft':'#F5F5F5','text-primary':'#212121','text-secondary':'#6B7280',divider:'#E0E0E0',error:'#DC3545',success:'#138808',warning:'#FFC107',info:'#17A2B8'},
+      boxShadow:{card:'0 1px 3px rgba(0,0,0,.1)',elevated:'0 4px 12px rgba(0,0,0,.15)'}
+    }}
+  }
+  </script>
+</head>
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
+    <main class="p-4 flex-grow">
+      <h1 class="text-lg font-bold text-text-primary mb-4">Dashboard</h1>
+      <div class="grid grid-cols-2 gap-4">
+        <a href="item-list.html" class="bg-background-soft rounded-lg shadow-card p-4 flex flex-col items-center">
+          <img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="w-10 mb-2" />
+          <span>Items</span>
+        </a>
+        <a href="order-list.html" class="bg-background-soft rounded-lg shadow-card p-4 flex flex-col items-center">
+          <img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="w-10 mb-2" />
+          <span>Orders</span>
+        </a>
+        <a href="vendor-wallet.html" class="bg-background-soft rounded-lg shadow-card p-4 flex flex-col items-center">
+          <img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="w-10 mb-2" />
+          <span>Wallet</span>
+        </a>
+        <a href="issue-center.html" class="bg-background-soft rounded-lg shadow-card p-4 flex flex-col items-center">
+          <img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="w-10 mb-2" />
+          <span>Issues</span>
+        </a>
+      </div>
+    </main>
+    <nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+      <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+      <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+      <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+      <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+      <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+    </nav>
+  </div>
+</body>
+</html>

--- a/vendor-index.html
+++ b/vendor-index.html
@@ -32,19 +32,22 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Habrio for Vendors</h1>
     <p class="text-sm text-text-secondary">Manage your shop, fulfill orders, and grow your business.</p>
     <a href="vendor-login.html" class="inline-block px-6 py-3 bg-blue-600 text-white rounded hover:bg-blue-700">Login as Vendor</a>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/vendor-kyc.html
+++ b/vendor-kyc.html
@@ -32,21 +32,22 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">KYC Setup</h1>
     <form action="create-shop.html" method="get" class="space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Business Name</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="John Doe" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Business Type</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">GST Number</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="Sample" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Address</label>
@@ -55,13 +56,15 @@ tailwind.config = {
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Continue</button>
     </form>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/vendor-login.html
+++ b/vendor-login.html
@@ -31,24 +31,27 @@ tailwind.config = {
 </script>
 <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Vendor Login</h1>
     <form action="vendor-basic-onboarding.html" method="get" class="space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Phone Number</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="9999999999" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Submit</button>
     </form>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/vendor-profile.html
+++ b/vendor-profile.html
@@ -31,7 +31,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <header class="max-w-lg mx-auto mb-6 text-center">
     <h1 class="text-lg font-bold text-text-primary mb-4">Vendor Profile</h1>
   </header>
@@ -53,13 +54,15 @@ tailwind.config = {
       <a href="edit-vendor-profile.html" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Edit Profile</a>
     </div>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/vendor-wallet.html
+++ b/vendor-wallet.html
@@ -32,14 +32,15 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <header class="max-w-2xl mx-auto mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">My Wallet</h1>
   </header>
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <div class="bg-white p-4 rounded shadow text-center space-y-2">
       <p class="text-sm text-text-secondary">Wallet Balance</p>
-      <p class="text-sm text-text-secondary">₹1 250.00</p>
+      <p class="text-sm text-text-secondary">₹1500.00</p>
       <a href="withdraw.html" class="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">Withdraw to Bank</a>
     </div>
     <div class="bg-white p-4 rounded shadow">
@@ -76,13 +77,15 @@ tailwind.config = {
       </table>
     </div>
   </main>
-  <footer class="fixed bottom-0 left-0 right-0 bg-background shadow-card py-2 flex justify-around text-sm">
-    <a href="vendor-dashboard.html" class="text-blue-600">Dashboard</a>
-    <a href="item-list.html" class="text-blue-600">Items</a>
-    <a href="order-list.html" class="text-blue-600">Orders</a>
-    <a href="vendor-wallet.html" class="text-blue-600">Wallet</a>
-    <a href="issue-center.html" class="text-blue-600">Issues</a>
-    <a href="vendor-profile.html" class="text-blue-600">Profile</a>
-  </footer>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
+</nav>
+  
+</div>
 </body>
 </html>

--- a/verify-otp.html
+++ b/verify-otp.html
@@ -32,13 +32,14 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
     <h1 class="text-lg font-bold text-text-primary mb-4">Verify OTP</h1>
     <form action="basic-onboarding.html" method="get" class="space-y-4">
       <div>
         <label class="text-sm text-text-secondary">OTP</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="123456" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Verify</button>
     </form>
@@ -46,13 +47,17 @@ tailwind.config = {
       <a href="#" class="text-blue-600 hover:underline">Resend OTP</a>
     </p>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>

--- a/wallet.html
+++ b/wallet.html
@@ -55,7 +55,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
 <main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
   <header class="w-full max-w-xl text-center mb-6">
     <h1 class="text-lg font-bold text-text-primary mb-4">My Wallet</h1>
@@ -63,24 +64,26 @@ tailwind.config = {
   <section class="w-full max-w-xl space-y-4">
     <div class="bg-white p-4 rounded shadow text-center space-y-2">
       <p class="text-sm text-text-secondary">Wallet Balance</p>
-      <p class="text-sm text-text-secondary">₹500</p>
+      <p class="text-sm text-text-secondary">₹1500.00</p>
     </div>
     <div class="bg-white p-4 rounded shadow">
       <h2 class="font-semibold mb-2">Transactions</h2>
       <ul class="text-sm space-y-1">
-        <li class="flex justify-between"><span>Added</span><span>+₹200</span></li>
-        <li class="flex justify-between"><span>Payment</span><span>-₹100</span></li>
-        <li class="flex justify-between"><span>Refund</span><span>+₹50</span></li>
+        <li class="flex justify-between"><span>Added</span><span>+₹700</span></li>
+        <li class="flex justify-between"><span>Payment</span><span>-₹200</span></li>
+        <li class="flex justify-between"><span>Refund</span><span>+₹100</span></li>
       </ul>
     </div>
   </section>
   
 </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Home</a>
+  <a href="cart.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/shopping-cart.svg" class="mx-auto w-5" />Cart</a>
+  <a href="order-history.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="profile.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/user-circle.svg" class="mx-auto w-5" />Profile</a>
+  <a href="wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
 </nav>
+</div>
 </body>
 </html>

--- a/withdraw.html
+++ b/withdraw.html
@@ -31,7 +31,8 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft">
+<body class="min-h-screen bg-background-soft flex flex-col items-center">
+  <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative">
   <header class="max-w-lg mx-auto mb-6 text-center">
     <h1 class="text-lg font-bold text-text-primary mb-4">Withdraw Funds</h1>
   </header>
@@ -39,22 +40,26 @@ tailwind.config = {
     <form action="vendor-wallet.html" method="get" class="bg-white p-4 rounded shadow space-y-4">
       <div>
         <label class="text-sm text-text-secondary">Amount</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="500" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <div>
         <label class="text-sm text-text-secondary">Bank Account</label>
-        <input class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
+        <input value="XXXXXX1234" class="w-full border border-divider rounded-md p-3 mb-3 focus:outline-none focus:ring-2 focus:ring-primary">
       </div>
       <button class="w-full py-3 rounded-md bg-primary text-white hover:bg-primary-dark transition">Withdraw</button>
     </form>
   </main>
-<nav class="fixed bottom-0 left-0 right-0 max-w-sm mx-auto flex justify-between bg-background shadow-card p-2 text-xs">
-  <a href="index.html" class="flex-1 text-center">Home</a>
-  <a href="cart.html" class="flex-1 text-center">Cart</a>
-  <a href="order-history.html" class="flex-1 text-center">Orders</a>
-  <a href="profile.html" class="flex-1 text-center">Profile</a>
+
+<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+  <a href="vendor-home.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/home.svg" class="mx-auto w-5" />Dash</a>
+  <a href="item-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/squares-plus.svg" class="mx-auto w-5" />Items</a>
+  <a href="order-list.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/clipboard-document-list.svg" class="mx-auto w-5" />Orders</a>
+  <a href="vendor-wallet.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/wallet.svg" class="mx-auto w-5" />Wallet</a>
+  <a href="issue-center.html" class="flex-1 py-3 text-center text-xs"><img src="https://unpkg.com/heroicons@2.1.0/24/exclamation-circle.svg" class="mx-auto w-5" />Issues</a>
 </nav>
 
+
   
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign all pages inside 390px device frame
- add bottom navigation with Heroicons
- prefill form fields with sample data
- create customer and vendor home screens
- update wallet samples

## Testing
- `python3 update_html.py`


------
https://chatgpt.com/codex/tasks/task_e_6889c5c2bd9083338294e38e166f7b5b