### PR TITLE
Enhance consumer home screens

### DIFF
--- a/consumer/customer-home.html
+++ b/consumer/customer-home.html
@@ -8,17 +8,15 @@
   <script>
   tailwind.config = {
     theme:{extend:{
-      colors:{primary:'#FF9933','primary-dark':'#e68a00',accent:'#138808','accent-dark':'#0f6a06',background:'#FFFFFF','background-soft':'#F5F5F5','text-primary':'#212121','text-secondary':'#6B7280',divider:'#E0E0E0',error:'#DC3545',success:'#138808',warning:'#FFC107',info:'#17A2B8'},
+      colors:{primary:'#FF671F','primary-dark':'#e05500',accent:'#138808','accent-dark':'#0f6a06',background:'#FFFFFF','background-soft':'#F8F9FA','text-primary':'#212121','text-secondary':'#6B7280',divider:'#E0E0E0',error:'#DC3545',success:'#138808',warning:'#FFC107',info:'#17A2B8'},
       boxShadow:{card:'0 1px 3px rgba(0,0,0,.1)',elevated:'0 4px 12px rgba(0,0,0,.15)'}
     }}
   }
   </script>
 </head>
-<body class="min-h-screen bg-background-soft flex flex-col items-center">
+<body class="min-h-screen bg-background-soft flex flex-col items-center pb-20">
   <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative"><main class="p-4 flex-grow">
-    <div class="w-full h-40 flex items-center justify-center rounded mb-4 bg-background-soft"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 10.5V6a3.75 3.75 0 1 0-7.5 0v4.5m11.356-1.993 1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 0 1-1.12-1.243l1.264-12A1.125 1.125 0 0 1 5.513 7.5h12.974c.576 0 1.059.435 1.119 1.007ZM8.625 10.5a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm7.5 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"/>
-</svg></div>
+    <div class="w-full h-60 bg-gradient-to-b from-primary to-accent rounded-b-lg flex flex-col items-center justify-center text-white mb-4"><h1 class="text-3xl font-bold">Welcome</h1><p class="text-sm opacity-80">Select an option to get started</p></div>
       <h1 class="text-xl font-bold text-text-primary">Welcome</h1>
       <div class="grid grid-cols-2 gap-4">
         <a href="shops.html" class="bg-background-soft rounded-lg shadow-card p-4 flex flex-col items-center">
@@ -48,7 +46,7 @@
       </div>
     </main>
 
-<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+<nav class="flex justify-between bg-background border-t border-divider fixed bottom-0 inset-x-0">
   <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><svg class="mx-auto w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
   <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
 </svg>Home</a>

--- a/consumer/index.html
+++ b/consumer/index.html
@@ -12,9 +12,9 @@ tailwind.config = {
     screens:      { sm:'640px', md:'768px', lg:'1024px', xl:'1280px', '2xl':'1536px' },
     extend: {
       colors:{
-        primary:'#FF9933', 'primary-dark':'#e68a00',
+        primary:'#FF671F','primary-dark':'#e05500',
         accent:'#138808','accent-dark':'#0f6a06',
-        background:'#FFFFFF','background-soft':'#F5F5F5',
+        background:'#FFFFFF','background-soft':'#F8F9FA',
         'text-primary':'#212121','text-secondary':'#6B7280', divider:'#E0E0E0',
         error:'#DC3545',success:'#138808',warning:'#FFC107',info:'#17A2B8'
       },
@@ -32,16 +32,19 @@ tailwind.config = {
 <script src="https://cdn.tailwindcss.com"></script>
 
 </head>
-<body class="min-h-screen bg-background-soft flex flex-col items-center">
+<body class="min-h-screen bg-background-soft flex flex-col items-center pb-20">
   <div class="w-[390px] max-w-full min-h-screen bg-background shadow-elevated flex flex-col relative"><main class="max-w-sm mx-auto bg-background shadow-card rounded-lg p-4">
-    <div class="w-full h-40 flex items-center justify-center rounded mb-4 bg-background-soft"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 10.5V6a3.75 3.75 0 1 0-7.5 0v4.5m11.356-1.993 1.263 12c.07.665-.45 1.243-1.119 1.243H4.25a1.125 1.125 0 0 1-1.12-1.243l1.264-12A1.125 1.125 0 0 1 5.513 7.5h12.974c.576 0 1.059.435 1.119 1.007ZM8.625 10.5a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm7.5 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"/>
-</svg></div>
+    <div class="w-full h-60 bg-gradient-to-b from-primary to-accent rounded-b-lg flex flex-col items-center justify-center text-white mb-4"><h1 class="text-3xl font-bold">Habrio</h1><p class="text-sm opacity-80">Bringing Local Convenience Online</p></div>
     <h1 class="text-xl font-bold text-text-primary">Welcome to Habrio</h1>
     <a href="login.html" class="inline-block px-6 py-3 bg-primary text-white rounded hover:bg-primary-dark">Login / Get Started</a>
+    <div class="mt-8 space-y-4">
+      <div class="flex items-center space-x-3"><span class="w-3 h-3 bg-primary rounded-full"></span><span class="text-text-secondary">Discover nearby shops easily</span></div>
+      <div class="flex items-center space-x-3"><span class="w-3 h-3 bg-accent rounded-full"></span><span class="text-text-secondary">Track orders in real-time</span></div>
+      <div class="flex items-center space-x-3"><span class="w-3 h-3 bg-primary rounded-full"></span><span class="text-text-secondary">Secure payments &amp; wallet</span></div>
+    </div>
   </main>
 
-<nav class="flex justify-between bg-background border-t border-divider absolute bottom-0 inset-x-0">
+<nav class="flex justify-between bg-background border-t border-divider fixed bottom-0 inset-x-0">
   <a href="customer-home.html" class="flex-1 py-3 text-center text-xs"><svg class="mx-auto w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" data-slot="icon">
   <path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
 </svg>Home</a>


### PR DESCRIPTION
## Summary
- apply Habrio Orange and Green to tailwind config
- redesign consumer index and home screens with colorful hero sections
- keep bottom navigation fixed for mobile view

## Testing
- `python3 -m py_compile update_html.py transform.py`

------
https://chatgpt.com/codex/tasks/task_e_6889f51e62888333962f15abb542899f