### PR TITLE
Fix nav width and add image assets

### DIFF
--- a/images/image.txt
+++ b/images/image.txt
@@ -1,0 +1,5 @@
+# Image generation prompts for SORA AI
+# Each image should be 100x100 pixels with a simple design inspired by Habrio brand colors (primary #FF6F00 and accent #43A047).
+# shop1.png - storefront illustration on white background
+# shop2.png - pharmacy icon on white background
+# shop3.png - laundry service icon on white background

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
     <!-- Shop Listings -->
     <main class="flex-1 overflow-y-auto px-4 space-y-4">
       <div class="bg-white rounded-lg shadow-md flex overflow-hidden">
-        <img src="https://via.placeholder.com/100" alt="Shop" class="w-24 h-24 object-cover">
+        <img src="images/shop1.png" alt="Shop" class="w-24 h-24 object-cover">
         <div class="p-4 flex flex-col justify-between flex-1">
           <div>
             <h3 class="text-lg font-semibold">Local Grocery</h3>
@@ -85,7 +85,7 @@
       </div>
 
       <div class="bg-white rounded-lg shadow-md flex overflow-hidden">
-        <img src="https://via.placeholder.com/100" alt="Shop" class="w-24 h-24 object-cover">
+        <img src="images/shop2.png" alt="Shop" class="w-24 h-24 object-cover">
         <div class="p-4 flex flex-col justify-between flex-1">
           <div>
             <h3 class="text-lg font-semibold">Neighborhood Pharmacy</h3>
@@ -99,7 +99,7 @@
       </div>
 
       <div class="bg-white rounded-lg shadow-md flex overflow-hidden">
-        <img src="https://via.placeholder.com/100" alt="Shop" class="w-24 h-24 object-cover">
+        <img src="images/shop3.png" alt="Shop" class="w-24 h-24 object-cover">
         <div class="p-4 flex flex-col justify-between flex-1">
           <div>
             <h3 class="text-lg font-semibold">Speedy Laundry</h3>
@@ -114,7 +114,7 @@
     </main>
 
     <!-- Bottom Navigation Bar -->
-    <nav class="flex justify-around bg-white border-t shadow fixed bottom-0 inset-x-0 py-2">
+    <nav class="flex justify-around bg-white border-t shadow fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-md py-2">
       <a href="#" class="flex flex-col items-center text-primary text-xs">
         <img src="icons/home.svg" alt="Home" class="w-6 h-6 mb-1">
         Home


### PR DESCRIPTION
## Summary
- adjust bottom navigation bar to stay within mobile layout
- swap placeholder images for local files
- add `images` folder with prompts for artwork
- remove placeholder images now that prompts are available

## Testing
- `python3 -m py_compile transform.py update_html.py`


------
https://chatgpt.com/codex/tasks/task_e_688b0894e94c833392937cceaaf8c748